### PR TITLE
Modernize design

### DIFF
--- a/_includes/archive.html
+++ b/_includes/archive.html
@@ -1,4 +1,4 @@
-<div class="mod shadow">
+<div>
     <div class="inner">
         <div class="bd">
         	<h2>Posts archive</h2>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,14 +1,13 @@
 ---
 layout: default
 ---
-<div class="mod shadow">
+<div>
     <div class="inner">
         <div class="bd">
             <article>
                 <a href="{{ page.url }}"><h1>{{ page.title }}</h1></a>
 
                 <p class="neutral">{% include byline.html date=page.date authors=page.authors path=page.path %}</p>
-                <hr>
 
                 <div class="post-content r-margin">
                     {{ content }}
@@ -35,7 +34,7 @@ layout: default
         </div>
     </div>
 </div>
-<aside class="mod shadow">
+<aside>
     <div class="inner">
         <div class="bd">
             <div id="disqus_thread" class="r-margin"></div>

--- a/css/tech_finn.css
+++ b/css/tech_finn.css
@@ -1,5 +1,9 @@
-body{
-	font: 16px/1.5 finnmain,Arial,Helvetica,sans-serif;
+body, html {
+	background-color: white;
+}
+
+body {
+	font: 1em finnmain,Arial,Helvetica,sans-serif;
 }
 
 .tagline {
@@ -24,6 +28,11 @@ body{
 
 .post-content blockquote { padding: 10px 20px; background-color: #F6F8DA; border-radius: 4px; }
 .post-content ul { padding-left: 20px; list-style: disc outside; }
+
+.post-content p, li { line-height: 26px; }
+.post-content b, .b1 { line-height: 20px; }
+
+.bd li a { line-height: 20px; }
 
 .ftlogo {
 	width: 80px;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: page
 title: Developers at FINN blogging about tech
 ---
 
-<div class="mod shadow">
+<div>
     <div class="inner">
         <div class="bd">
             {% for post in paginator.posts %}
@@ -15,7 +15,6 @@ title: Developers at FINN blogging about tech
                 </h1>
 
                 <p class="neutral">{% include byline.html date=post.date authors=post.authors %}</p>
-                <hr>
 
                 <div class="post-content r-margin">
                     {{ post.content }}

--- a/tags/index.html
+++ b/tags/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 ---
-<div class="mod shadow">
+<div>
     <div class="inner">
         <div class="bd">
 {% capture tags %}{% for tag in site.tags %}{{ tag[0] }}{% if forloop.last != true %}|{% endif %}{% endfor %}{% endcapture %}


### PR DESCRIPTION
Updated the styling so it follows what we've done on the new FINN.no page, uses a more consistent `line-height` as well as usage of `em` font instead of `px`. 

![index](https://user-images.githubusercontent.com/1088217/32178120-4189b59c-bd8c-11e7-8148-73d393774422.jpg)

![article](https://user-images.githubusercontent.com/1088217/32178128-459cb51c-bd8c-11e7-9820-6c910a115118.jpg)
