### PR TITLE
Fix tapping home doesn't take you home

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ relative_permalinks: false
 
 title:            FINN Technology
 tagline:          <a href="//finn.no/apply-here">Join us?</a>
-url:              https://tech.finn.no
+url:              ""
 paginate:         1
 paginate_path:    "page/:num"
 google_analytics_id: UA-32205740-1

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,11 +9,11 @@
             <header>
                 <div class="display-table mvm dark-links">
                     <div class="display-cell ftlogo">
-                        <a href="{{ site.baseurl }}"><img src="/images/tech_logo2.png" alt="FINN.no"></a>
+                        <a href="{{ site.url }}"><img src="/images/tech_logo2.png" alt="FINN.no"></a>
                     </div>
                     <div class="display-cell">
                         <h2>
-                            <a href="{{ site.baseurl }}" title="Home">{{ site.title }}</a>
+                            <a href="{{ site.url }}" title="Home">{{ site.title }}</a>
                             <small class="tagline">{{ site.tagline }}</small>
                         </h2>
                     </div>


### PR DESCRIPTION
I think we've been using baseurl incorrectly in a few places, when we should have used `site.url` instead.

# Before
![home1](https://user-images.githubusercontent.com/1088217/32183526-d7920d8e-bd99-11e7-8bef-4d0ee0d3195d.gif)


# After
![home2](https://user-images.githubusercontent.com/1088217/32183534-dbb53bf2-bd99-11e7-8054-b2d7a4de6b60.gif)
