### PR TITLE
Change default site.url to use HTTPS URL of the CNAME

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ relative_permalinks: false
 
 title:            FINN Technology
 tagline:          <a href="//finn.no/apply-here">Join us?</a>
-url:              ""
+url:              "https://tech.finn.no"
 paginate:         1
 paginate_path:    "page/:num"
 google_analytics_id: UA-32205740-1

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,11 +9,11 @@
             <header>
                 <div class="display-table mvm dark-links">
                     <div class="display-cell ftlogo">
-                        <a href="{{ site.baseurl | relative_url }}"><img src="/images/tech_logo2.png" alt="FINN.no"></a>
+                        <a href="{{ site.url }}/"><img src="/images/tech_logo2.png" alt="FINN.no"></a>
                     </div>
                     <div class="display-cell">
                         <h2>
-                            <a href="{{ site.baseurl | relative_url }}" title="Home">{{ site.title }}</a>
+                            <a href="{{ site.url }}/" title="Home">{{ site.title }}</a>
                             <small class="tagline">{{ site.tagline }}</small>
                         </h2>
                     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
                     {{ content }}
                     Tags:
                     {% for tag in page.tags %}
-                    <a href="{{ site.baseurl | relative_url }}tags#{{ tag }}" data-proofer-ignore>{{ tag }}</a>
+                    <a href="{{ site.url }}/tags#{{ tag }}" data-proofer-ignore>{{ tag }}</a>
                     {% endfor %}
                 </div>
             </article>


### PR DESCRIPTION
Another attempt at fixing the URLs for tags and tapping home button.

I thought this was fixed in

* 1206d07 (Fix link for tags on tech.finn.no/tags, 2018-11-24)
* a5d6d9f (Trying again to fix home tap, 2018-11-24)

but when visiting the blog it did not work.

I am still not sure if it will work but this time I tested this on one
of my [own domains][0] using a different CNAME. It worked there and
localhost is still functional.

[0]: https://tech.finn.xdp.no